### PR TITLE
codegen: fix handling of methods with variant parameters

### DIFF
--- a/codegen_glibmm/templates/proxy.h.templ
+++ b/codegen_glibmm/templates/proxy.h.templ
@@ -42,7 +42,7 @@ public:
         {% for arg in method.in_args %}
         {% if arg.templated %}
         Glib::Variant<Glib::Variant<T>> {{ arg.name }}_variantValue =
-            Glib::Variant<Glib::Variant<T>>::create(Glib::Variant<T>::create({{ arg.name }}_param));
+            Glib::Variant<Glib::Variant<T>>::create(Glib::Variant<T>::create({{ arg.name }}));
         params.push_back({{ arg.name }}_variantValue);
         {% else %}
         {{ arg.cppvalue_send(arg.name + "_param", arg.name, interface.cpp_class_name) }}

--- a/codegen_glibmm/templates/stub.cpp.templ
+++ b/codegen_glibmm/templates/stub.cpp.templ
@@ -75,9 +75,11 @@ void {{ interface.cpp_namespace_name}}::on_method_call(
 {
 {% for method in interface.methods %}
     if (method_name.compare("{{ method.name }}") == 0) {
-    {% for arg in method.in_args %}
         {% if method is templated %}
         Glib::VariantContainerBase containerBase = parameters;
+        {% endif %}
+    {% for arg in method.in_args %}
+        {% if arg.templated %}
         GVariant *output{{ loop.index0 }};
         g_variant_get_child(containerBase.gobj(), {{ loop.index0 }}, "v", &output{{ loop.index0 }});
         Glib::VariantBase p_{{ arg.name }} =

--- a/tests/integration/common/many-types.xml
+++ b/tests/integration/common/many-types.xml
@@ -22,6 +22,13 @@
        <arg type="v" name="Param2" direction="out"></arg>
     </method>
 
+    <method name="TestVariant2">
+       <arg type="s" name="Param1" direction="in"></arg>
+       <arg type="v" name="Param2" direction="in"></arg>
+       <arg type="s" name="Param3" direction="out"></arg>
+       <arg type="v" name="Param4" direction="out"></arg>
+    </method>
+
     <method name="TestByteStringArray">
         <arg type="aay" name="Param1" direction="in"></arg>
         <arg type="aay" name="Param2" direction="out"></arg>

--- a/tests/integration/proxy/testproxymain.cpp
+++ b/tests/integration/proxy/testproxymain.cpp
@@ -74,6 +74,26 @@ void on_test_variant_finished(const Glib::RefPtr<Gio::AsyncResult> result, Glib:
     printStatus("Variant", value == expectedValue);
 }
 
+void on_test_variant2_finished(const Glib::RefPtr<Gio::AsyncResult> result,
+                               std::string expectedString,
+                               Glib::ustring expectedVariant)
+{
+    std::string string;
+    Glib::VariantBase base;
+    proxy->TestVariant2_finish(string, base, result);
+
+    Glib::ustring value;
+    try {
+        Glib::Variant<Glib::ustring> res =
+            Glib::VariantBase::cast_dynamic<Glib::Variant<Glib::ustring>>(base);
+        value = res.get();
+    } catch (std::bad_cast e) {
+        std::cerr << e.what() << std::endl;
+    }
+
+    printStatus("Variant2", string == expectedString && value == expectedVariant);
+}
+
 void on_test_byte_string_array_finished (const Glib::RefPtr<Gio::AsyncResult> result, std::vector<std::string> expected) {
     std::vector<std::string> res;
     proxy->TestByteStringArray_finish(res, result);
@@ -499,6 +519,10 @@ void proxy_created(const Glib::RefPtr<Gio::AsyncResult> result) {
 
     /* Variant */
     proxy->TestVariant(variantValue, sigc::bind(sigc::ptr_fun(&on_test_variant_finished), variantValue));
+
+    /* Variant2 */
+    proxy->TestVariant2(stringValue, variantValue,
+                        sigc::bind(sigc::ptr_fun(&on_test_variant2_finished), stringValue, variantValue));
 
     /* Byte string array */
     proxy->TestByteStringArray(inputStrVec, sigc::bind(sigc::ptr_fun(&on_test_byte_string_array_finished), inputStrVec));

--- a/tests/integration/stub/teststubmain.cpp
+++ b/tests/integration/stub/teststubmain.cpp
@@ -95,6 +95,12 @@ void TestImpl::TestVariant(Glib::VariantBase Param1, TestMessageHelper invocatio
     invocation.ret(variantValue);
 }
 
+void TestImpl::TestVariant2(std::string Param1, Glib::VariantBase Param2,
+                            TestMessageHelper invocation)
+{
+    invocation.ret(Param1, Param2);
+}
+
 void TestImpl::TestByteStringArray (
         std::vector<std::string>  Param1,
         TestMessageHelper invocation) {

--- a/tests/integration/stub/teststubmain.h
+++ b/tests/integration/stub/teststubmain.h
@@ -7,6 +7,9 @@ public:
     void TestVariant (
             Glib::VariantBase Param1,
             TestMessageHelper invocation);
+    void TestVariant2(std::string Param1,
+                      Glib::VariantBase Param2,
+                      TestMessageHelper invocation) override;
     void TestStringVariantDict(
             std::map<Glib::ustring,Glib::VariantBase> Param1,
             TestMessageHelper invocation) override;


### PR DESCRIPTION
Methods accepting more than one parameter, where at least one of them is
a variant, were not generated correctly. This commit fixes that, and
adds a regression test.

Fixes: #28